### PR TITLE
Upgrade fork-ts-checker plugin & spread plugin options

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,7 +1,7 @@
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin')
 
 exports.onCreateWebpackConfig = ({ stage, actions }, options) => {
-  if (stage != 'develop') {
+  if (stage !== 'develop') {
     return
   }
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,6 +1,6 @@
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin')
 
-exports.onCreateWebpackConfig = ({ stage, actions }, {tslint}) => {
+exports.onCreateWebpackConfig = ({ stage, actions }, options) => {
   if (stage != 'develop') {
     return
   }
@@ -11,7 +11,7 @@ exports.onCreateWebpackConfig = ({ stage, actions }, {tslint}) => {
         async: false,
         silent: true,
         formatter: 'codeframe',
-        tslint,
+        ...options,
       }),
     ],
   })

--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
     "license": "MIT",
     "version": "1.0.3",
     "repository": "https://github.com/DaleJefferson/gatsby-plugin-typescript-checker",
-    "files": ["index.js", "gatsby-node.js"],
+    "files": [
+        "index.js",
+        "gatsby-node.js"
+    ],
     "keywords": [
         "gatsby",
         "gatsby-plugin",
@@ -16,6 +19,6 @@
         "test": "exit 0"
     },
     "dependencies": {
-        "fork-ts-checker-webpack-plugin": "^0.5.0"
+        "fork-ts-checker-webpack-plugin": "^1.3.4"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -377,17 +377,19 @@ for-in@^1.0.2:
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
   integrity sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=
 
-fork-ts-checker-webpack-plugin@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-0.5.0.tgz#39de03c2579368806478024cbce6ac7f5346d590"
-  integrity sha512-F8Xh0YBJEi1U0EGaYkTfc7IjDgQvBazGwBkoVytvcEIBeLHcqxYtwh5FkFcQdTsKZLWHGgtSJ78C3//RhpWFGw==
+fork-ts-checker-webpack-plugin@^1.3.4:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-1.3.4.tgz#a75b6fe8d3db0089555f083c4f77372227704244"
+  integrity sha512-2QDXnI2mbbly/OHx/ivtspi2l4K2g+IB0LTQ3AwsBfxyHtMFXtojlsJqGyhUggX08BC+F02CoCG0hRSPOLU2dQ==
   dependencies:
     babel-code-frame "^6.22.0"
     chalk "^2.4.1"
     chokidar "^2.0.4"
     micromatch "^3.1.10"
     minimatch "^3.0.4"
+    semver "^5.6.0"
     tapable "^1.0.0"
+    worker-rpc "^0.1.0"
 
 fragment-cache@^0.2.1:
   version "0.2.1"
@@ -722,6 +724,11 @@ map-visit@^1.0.0:
   integrity sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=
   dependencies:
     object-visit "^1.0.0"
+
+microevent.ts@~0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/microevent.ts/-/microevent.ts-0.1.1.tgz#70b09b83f43df5172d0205a63025bce0f7357fa0"
+  integrity sha512-jo1OfR4TaEwd5HOrt5+tAZ9mqT4jmpNAusXtyfNzqVm9uiSYFZlKM1wYL4oU7azZW/PxQW53wM0S6OR1JHNa2g==
 
 micromatch@^3.1.10, micromatch@^3.1.4:
   version "3.1.10"
@@ -1061,6 +1068,11 @@ semver@^5.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
   integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
 
+semver@^5.6.0:
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.0.tgz#790a7cf6fea5459bac96110b29b60412dc8ff96b"
+  integrity sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==
+
 set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
@@ -1299,6 +1311,13 @@ wide-align@^1.1.0:
   integrity sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==
   dependencies:
     string-width "^1.0.2 || 2"
+
+worker-rpc@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/worker-rpc/-/worker-rpc-0.1.1.tgz#cb565bd6d7071a8f16660686051e969ad32f54d5"
+  integrity sha512-P1WjMrUB3qgJNI9jfmpZ/htmBEjFh//6l/5y8SD9hg1Ef5zTTVVoRjTrTEzPrNBQvmhMxkoTsjOXN10GWU7aCg==
+  dependencies:
+    microevent.ts "~0.1.1"
 
 wrappy@1:
   version "1.0.2"


### PR DESCRIPTION
This PR upgrades the [`fork-ts-checker`](https://github.com/Realytics/fork-ts-checker-webpack-plugin) plugin to the latest version to make rebuilds around **75% faster**.

I made a simple benchmark on recovering from a missing TS type:
- Before: `3647ms`
- After: `886ms`

As far as I am aware of, there shouldn't be any breaking changes even with the major bump of fork-ts-checker. Quoting from the 1.0.0 release note:

> There are actually no breaking changes that we're aware of; users of 0.x fork-ts-checker-webpack-plugin should be be able to upgrade without any drama. Users of TypeScript 3+ may notice a performance improvement as by default the plugin now uses the incremental watch API in TypeScript. Should this prove problematic you can opt out of using it by supplying useTypescriptIncrementalApi: false.

In addition to that, I spread all the plugin options to the `fork-ts-checker` options to allow users to override all sensible defaults this gatsby plugin uses.

Fixes #1 